### PR TITLE
Updated s3 to remove unsupported region attribute

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -3,7 +3,6 @@
 ## S3 Bucket for Vault Data
 resource "aws_s3_bucket" "vault_data" {
   bucket_prefix = "${var.main_project_tag}-"
-  region = data.aws_region.current.name
 
   server_side_encryption_configuration {
     rule {


### PR DESCRIPTION
Region attribute has been removed from aws_s3_bucket and now causes a "computed attributes cannot be set" error, see: [https://github.com/hashicorp/terraform-provider-aws/issues/592](https://github.com/hashicorp/terraform-provider-aws/issues/592)

If region needs to be specifically set, this can be done with the provider attribute.